### PR TITLE
Ss4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Using this task, you can do the following:
 	- `sake dev/tasks/MigrateTask down`
 3. Make a new migration file for you with boilerplate code.
 	- `sake dev/tasks/MigrateTask make:migration_name`
-	- **Note:** This file will be automatically placed in your project directory in the path `<project>/code/migrations`. You can customize this location by defining a `MIGRATIONS_PATH` constant which should be the absolute path to the desired directory (either in your `_ss_environment.php` or `_config.php` files). Also, migration files that are automatically generated will be pseudo-namespaced with a `Migration_` prefix to help reduce possible class name collisions.
+	- **Note:** This file will be automatically placed in your project directory in the path `<project>/src/migrations`. You can customize this location by defining a `MIGRATIONS_PATH` constant which should be the absolute path to the desired directory (either in your `_ss_environment.php` or `_config.php` files). Also, migration files that are automatically generated will be pseudo-namespaced with a `Migration_` prefix to help reduce possible class name collisions.
 
 ### How it Works
 

--- a/code/DatabaseMigrations.php
+++ b/code/DatabaseMigrations.php
@@ -1,5 +1,12 @@
 <?php
 
+namespace Silverstripe\Migrations;
+
+
+use SilverStripe\ORM\DataObject;
+
+
+
 /**
  * DataObject used to keep track of previously run migrations.
  *

--- a/code/DatabaseMigrations.php
+++ b/code/DatabaseMigrations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silverstripe\Migrations;
+namespace SilverStripe\Migrations;
 
 
 use SilverStripe\ORM\DataObject;

--- a/code/DatabaseMigrations.php
+++ b/code/DatabaseMigrations.php
@@ -20,7 +20,7 @@ class DatabaseMigrations extends DataObject {
         "BaseName"          => "Varchar(255)",
         "MigrationClass"    => "Varchar(255)",
         "Batch"             => "Int",
-        "Stamp"             => "SS_DateTime",
+        "Stamp"             => "DBDatetime",
     );
 
 }

--- a/code/DatabaseMigrations.php
+++ b/code/DatabaseMigrations.php
@@ -2,10 +2,7 @@
 
 namespace PattricNelson\SilverStripeMigrations;
 
-
 use SilverStripe\ORM\DataObject;
-
-
 
 /**
  * DataObject used to keep track of previously run migrations.

--- a/code/DatabaseMigrations.php
+++ b/code/DatabaseMigrations.php
@@ -22,5 +22,5 @@ class DatabaseMigrations extends DataObject {
         "Batch"             => "Int",
         "Stamp"             => "DBDatetime",
     );
-
+    private static $table_name = 'DatabaseMigrations';
 }

--- a/code/DatabaseMigrations.php
+++ b/code/DatabaseMigrations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Migrations;
+namespace PattricNelson\SilverStripeMigrations;
 
 
 use SilverStripe\ORM\DataObject;

--- a/code/DatabaseMigrations.php
+++ b/code/DatabaseMigrations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PatricNelson\SilverStripeMigrations;
+namespace PatrickNelson\SilverStripeMigrations;
 
 use SilverStripe\ORM\DataObject;
 

--- a/code/DatabaseMigrations.php
+++ b/code/DatabaseMigrations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PattricNelson\SilverStripeMigrations;
+namespace PatricNelson\SilverStripeMigrations;
 
 use SilverStripe\ORM\DataObject;
 

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -4,14 +4,14 @@ namespace PattricNelson\SilverStripeMigrations;
 
 use Exception;
 
+use PattricNelson\SilverStripeMigrations\Migration;
+use PattricNelson\SilverStripeMigrations\MigrationBoilerplate;
 use ReflectionClass;
 use SilverStripe\Control\Director;
-use SilverStripe\ORM\DB;
-use PattricNelson\SilverStripeMigrations\MigrationBoilerplate;
-use SilverStripe\Core\Manifest\ClassLoader;
-use PattricNelson\SilverStripeMigrations\Migration;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Dev\BuildTask;
+use SilverStripe\ORM\DB;
 
 /**
  * Task which allows you to do the following:

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -1,5 +1,22 @@
 <?php
 
+namespace Silverstripe\Migrations;
+
+
+
+
+use Exception;
+
+use ReflectionClass;
+use SilverStripe\Control\Director;
+use SilverStripe\ORM\DB;
+use Silverstripe\Migrations\MigrationBoilerplate;
+use SilverStripe\Core\Manifest\ClassLoader;
+use Silverstripe\Migrations\Migration;
+use SilverStripe\Dev\BuildTask;
+
+
+
 /**
  * Task which allows you to do the following:
  *
@@ -253,7 +270,7 @@ class MigrateTask extends BuildTask {
         // Get boilerplate file contents, find/replace some contents and write to file path.
         $sourceFile = __DIR__ . DIRECTORY_SEPARATOR . "MigrationBoilerplate.php";
         $sourceData = file_get_contents($sourceFile);
-        $sourceData = str_replace("MigrationBoilerplate", $camelCase, $sourceData);
+        $sourceData = str_replace(MigrationBoilerplate::class, $camelCase, $sourceData);
         file_put_contents($filePath, $sourceData);
 
         // Output status and exit.
@@ -314,8 +331,8 @@ class MigrateTask extends BuildTask {
      */
     public static function getAllMigrations() {
         // Get all descendants of the abstract "Migration" class but ensure the class "MigrationBoilerplate" is skipped.
-        $manifest = SS_ClassLoader::instance()->getManifest();
-        $classes = array_diff($manifest->getDescendantsOf("Migration"), array("MigrationBoilerplate"));
+        $manifest = ClassLoader::instance()->getManifest();
+        $classes = array_diff($manifest->getDescendantsOf(Migration::class), array(MigrationBoilerplate::class));
         $classesOrdered = array();
         foreach ($classes as $className) {
             // Get actual filename of migration class and use that as the key.

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -13,8 +13,8 @@ use SilverStripe\ORM\DB;
 use PattricNelson\SilverStripeMigrations\MigrationBoilerplate;
 use SilverStripe\Core\Manifest\ClassLoader;
 use PattricNelson\SilverStripeMigrations\Migration;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
-
 
 
 /**
@@ -63,7 +63,7 @@ class MigrateTask extends BuildTask {
     protected $lastMigrationFile = '';
 
     /**
-     * @param    SS_HTTPRequest $request
+     * @param     HTTPRequest $request
      * @throws    MigrationException
      */
     public function run($request) {

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silverstripe\Migrations;
+namespace SilverStripe\Migrations;
 
 
 
@@ -10,9 +10,9 @@ use Exception;
 use ReflectionClass;
 use SilverStripe\Control\Director;
 use SilverStripe\ORM\DB;
-use Silverstripe\Migrations\MigrationBoilerplate;
+use SilverStripe\Migrations\MigrationBoilerplate;
 use SilverStripe\Core\Manifest\ClassLoader;
-use Silverstripe\Migrations\Migration;
+use SilverStripe\Migrations\Migration;
 use SilverStripe\Dev\BuildTask;
 
 

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Migrations;
+namespace PattricNelson\SilverStripeMigrations;
 
 
 
@@ -10,9 +10,9 @@ use Exception;
 use ReflectionClass;
 use SilverStripe\Control\Director;
 use SilverStripe\ORM\DB;
-use SilverStripe\Migrations\MigrationBoilerplate;
+use PattricNelson\SilverStripeMigrations\MigrationBoilerplate;
 use SilverStripe\Core\Manifest\ClassLoader;
-use SilverStripe\Migrations\Migration;
+use PattricNelson\SilverStripeMigrations\Migration;
 use SilverStripe\Dev\BuildTask;
 
 

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -32,7 +32,7 @@ use SilverStripe\Dev\BuildTask;
  *
  *        YYYY_MM_DD_HHMMSS_change_serialize_to_json.php
  *
- * IMPORTANT: This file will be automatically placed in your project directory in the path "<project>/code/migrations".
+ * IMPORTANT: This file will be automatically placed in your project directory in the path "<project>/src/migrations".
  * This can be overridden by defining an absolute path in the constant "MIGRATION_PATH" in your _ss_environment.php file.
  * Migration files that are automatically generated will be pseudo-namespaced with a "Migration_" prefix to help reduce
  * possible class name collisions.
@@ -57,6 +57,8 @@ class MigrateTask extends BuildTask {
 
     // Used for error reporting purposes.
     protected $lastMigrationFile = '';
+
+    private static $segment = 'MigrateTask';
 
     /**
      * @param     HTTPRequest $request
@@ -94,7 +96,7 @@ class MigrateTask extends BuildTask {
         register_shutdown_function(array($this, "shutdown"));
 
         // Determine action to take. Wrap everything in a transaction so it can be rolled back in case of error.
-        DB::getConn()->transactionStart();
+        DB::get_conn()->transactionStart();
         try {
             if (isset($args["up"])) {
                 $this->up();
@@ -110,7 +112,7 @@ class MigrateTask extends BuildTask {
             }
 
             // Commit and clean up error state..
-            DB::getConn()->transactionEnd();
+            DB::get_conn()->transactionEnd();
             $this->error = false;
 
         } catch (Exception $e) {
@@ -138,7 +140,7 @@ class MigrateTask extends BuildTask {
         if ($this->error && !$e) $e = new MigrationException("The migration" . ($this->lastMigrationFile ? " '$this->lastMigrationFile.php'" : "") . " terminated unexpectedly.");
         if ($e) {
             // Rollback database changes and notify user.
-            DB::getConn()->transactionRollback();
+            DB::get_conn()->transactionRollback();
             $this->output("ERROR" . ($e->getCode() != 0 ? " (" . $e->getCode() . ")" : "") . ": " . $e->getMessage());
             $this->output("\nNote: Any database changes have been rolled back.");
             $this->output("\nStack Trace:");
@@ -263,9 +265,12 @@ class MigrateTask extends BuildTask {
         }
 
         // Get boilerplate file contents, find/replace some contents and write to file path.
-        $sourceFile = __DIR__ . DIRECTORY_SEPARATOR . "MigrationBoilerplate.php";
-        $sourceData = file_get_contents($sourceFile);
-        $sourceData = str_replace(MigrationBoilerplate::class, $camelCase, $sourceData);
+        $reflect = new ReflectionClass(MigrationBoilerplate::class);
+        $sourceData = str_replace(
+            [$reflect->getShortName(), 'namespace '.$reflect->getNamespaceName()],
+            [$camelCase, 'use '.Migration::class],
+            file_get_contents($reflect->getFileName())
+        );
         file_put_contents($filePath, $sourceData);
 
         // Output status and exit.
@@ -312,7 +317,7 @@ class MigrateTask extends BuildTask {
             if (empty($project)) throw new MigrationException("Please either define a global '\$project' variable or define a MIGRATION_PATH constant in order to setup a path for migration files to live.");
 
             // Build path.
-            $migrationPath = join(DIRECTORY_SEPARATOR, array(BASE_PATH, $project, "code", "migrations"));
+            $migrationPath = join(DIRECTORY_SEPARATOR, array(BASE_PATH, $project, "src", "migrations"));
         }
 
         return $migrationPath;

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -325,7 +325,7 @@ class MigrateTask extends BuildTask {
      */
     public static function getAllMigrations() {
         // Get all descendants of the abstract "Migration" class but ensure the class "MigrationBoilerplate" is skipped.
-        $manifest = ClassLoader::instance()->getManifest();
+        $manifest = ClassLoader::inst()->getManifest();
         $classes = array_diff($manifest->getDescendantsOf(Migration::class), array(MigrationBoilerplate::class));
         $classesOrdered = array();
         foreach ($classes as $className) {

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -2,9 +2,6 @@
 
 namespace PattricNelson\SilverStripeMigrations;
 
-
-
-
 use Exception;
 
 use ReflectionClass;
@@ -15,7 +12,6 @@ use SilverStripe\Core\Manifest\ClassLoader;
 use PattricNelson\SilverStripeMigrations\Migration;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
-
 
 /**
  * Task which allows you to do the following:
@@ -160,7 +156,6 @@ class MigrateTask extends BuildTask {
         return Director::is_cli();
     }
 
-
     ########################
     ## MAIN FUNCTIONALITY ##
     ########################
@@ -276,7 +271,6 @@ class MigrateTask extends BuildTask {
         // Output status and exit.
         $this->output("Created new migration: $filePath");
     }
-
 
     ####################
     ## HELPER METHODS ##

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace PatricNelson\SilverStripeMigrations;
+namespace PatrickNelson\SilverStripeMigrations;
 
 use Exception;
 
-use PatricNelson\SilverStripeMigrations\Migration;
-use PatricNelson\SilverStripeMigrations\MigrationBoilerplate;
+use PatrickNelson\SilverStripeMigrations\Migration;
+use PatrickNelson\SilverStripeMigrations\MigrationBoilerplate;
 use ReflectionClass;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;

--- a/code/MigrateTask.php
+++ b/code/MigrateTask.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace PattricNelson\SilverStripeMigrations;
+namespace PatricNelson\SilverStripeMigrations;
 
 use Exception;
 
-use PattricNelson\SilverStripeMigrations\Migration;
-use PattricNelson\SilverStripeMigrations\MigrationBoilerplate;
+use PatricNelson\SilverStripeMigrations\Migration;
+use PatricNelson\SilverStripeMigrations\MigrationBoilerplate;
 use ReflectionClass;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;

--- a/code/Migration.php
+++ b/code/Migration.php
@@ -110,8 +110,8 @@ abstract class Migration implements MigrationInterface {
         // Let's get our hands dirty on this ancestry filth and reference the database because the private static ::$db isn't reliable (seriously).
         $ancestors = ClassInfo::ancestry($className, true);
         foreach($ancestors as $ancestor) {
-            if ($tableName = DataObject::getSchema()->tableName($ancestor)) {
-                if (DB::get_schema()->hasField($tableName, $field)) return $ancestor;
+            if ($tableName = DataObject::getSchema()->tableForField($ancestor, $field)) {
+                return $ancestor;
             }
         }
 

--- a/code/Migration.php
+++ b/code/Migration.php
@@ -125,8 +125,8 @@ abstract class Migration implements MigrationInterface {
         // Let's get our hands dirty on this ancestry filth and reference the database because the private static ::$db isn't reliable (seriously).
         $ancestors = ClassInfo::ancestry($className, true);
         foreach($ancestors as $ancestor) {
-            if (DataObject::getSchema()->classHasTable($ancestor)) {
-                if (DB::get_schema()->hasField($ancestor, $field)) return $ancestor;
+            if ($tableName = DataObject::getSchema()->tableName($ancestor)) {
+                if (DB::get_schema()->hasField($tableName, $field)) return $ancestor;
             }
         }
 

--- a/code/Migration.php
+++ b/code/Migration.php
@@ -2,19 +2,7 @@
 
 namespace PattricNelson\SilverStripeMigrations;
 
-
-
-
-
-
-
-
-
 use Exception;
-
-
-
-
 
 use SilverStripe\ORM\DB;
 use SilverStripe\Core\ClassInfo;
@@ -30,8 +18,6 @@ use SilverStripe\Control\Session;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\Queries\SQLDelete;
 use SilverStripe\Versioned\Versioned;
-
-
 
 /**
  * All migrations that must be executed must be descended from this class and define both an ->up() and a ->down()
@@ -59,7 +45,6 @@ abstract class Migration implements MigrationInterface {
     public function isObsolete() {
         return $this->obsolete;
     }
-
 
     #######################################
     ## DATABASE MIGRATION HELPER METHODS ##

--- a/code/Migration.php
+++ b/code/Migration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silverstripe\Migrations;
+namespace SilverStripe\Migrations;
 
 
 
@@ -125,7 +125,7 @@ abstract class Migration implements MigrationInterface {
         // Let's get our hands dirty on this ancestry filth and reference the database because the private static ::$db isn't reliable (seriously).
         $ancestors = ClassInfo::ancestry($className, true);
         foreach($ancestors as $ancestor) {
-            if (DataObject::has_own_table($ancestor)) {
+            if (DataObject::getSchema()->classHasTable($ancestor)) {
                 if (DB::get_schema()->hasField($ancestor, $field)) return $ancestor;
             }
         }
@@ -300,8 +300,8 @@ abstract class Migration implements MigrationInterface {
     public static function publish(SiteTree $page, $force = true) {
         try {
             static::whileAdmin(function () use ($page, $force) {
-                if (!$page->getIsModifiedOnStage() || $force) {
-                    $page->doPublish();
+                if (!$page->isModifiedOnDraft() || $force) {
+                    $page->publishRecursive();
                 } else {
                     $page->write();
                 }

--- a/code/Migration.php
+++ b/code/Migration.php
@@ -4,19 +4,19 @@ namespace PattricNelson\SilverStripeMigrations;
 
 use Exception;
 
-use SilverStripe\ORM\DB;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\Session;
 use SilverStripe\Core\ClassInfo;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Core\Convert;
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLDelete;
+use SilverStripe\ORM\Queries\SQLInsert;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\ORM\Queries\SQLUpdate;
-use SilverStripe\ORM\Queries\SQLInsert;
-use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
-use SilverStripe\Control\Session;
-use SilverStripe\Dev\Deprecation;
-use SilverStripe\ORM\Queries\SQLDelete;
 use SilverStripe\Versioned\Versioned;
 
 /**

--- a/code/Migration.php
+++ b/code/Migration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Migrations;
+namespace PattricNelson\SilverStripeMigrations;
 
 
 

--- a/code/Migration.php
+++ b/code/Migration.php
@@ -1,5 +1,38 @@
 <?php
 
+namespace Silverstripe\Migrations;
+
+
+
+
+
+
+
+
+
+use Exception;
+
+
+
+
+
+use SilverStripe\ORM\DB;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Core\Convert;
+use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\ORM\Queries\SQLUpdate;
+use SilverStripe\ORM\Queries\SQLInsert;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
+use SilverStripe\Control\Session;
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\ORM\Queries\SQLDelete;
+use SilverStripe\Versioned\Versioned;
+
+
+
 /**
  * All migrations that must be executed must be descended from this class and define both an ->up() and a ->down()
  * method. Migrations will be executed in alphanumeric order
@@ -387,7 +420,7 @@ abstract class Migration implements MigrationInterface {
      * @throws    MigrationException
      */
     public static function setPageType(SiteTree $page, $pageType) {
-        if (!is_a($pageType, "SiteTree", true)) throw new MigrationException("The specifed page type '$pageType' must be an instance (or child) of 'SiteTree'.");
+        if (!is_a($pageType, SiteTree::class, true)) throw new MigrationException("The specifed page type '$pageType' must be an instance (or child) of 'SiteTree'.");
         $page = $page->newClassInstance($pageType);
         static::publish($page);
     }
@@ -502,11 +535,11 @@ abstract class Migration implements MigrationInterface {
         // Quick validation.
         foreach(array($fromObject, $toObject) as $validateObject) {
             if (!class_exists($validateObject)) throw new MigrationException("'$validateObject' doesn't appear to be an object.");
-            if (is_a($validateObject, 'DataObject')) throw new MigrationException("'$validateObject' must be an instance of DataObject.");
+            if (is_a($validateObject, DataObject::class)) throw new MigrationException("'$validateObject' must be an instance of DataObject.");
 
             /** @var $validateInstance DataObject */
             $validateInstance = singleton($validateObject);
-            if (!$validateInstance->hasExtension('Versioned')) throw new MigrationException("'$validateObject' must be a versioned object (i.e. have the Versioned extension).");
+            if (!$validateInstance->hasExtension(Versioned::class)) throw new MigrationException("'$validateObject' must be a versioned object (i.e. have the Versioned extension).");
         }
 
         // Repeat on each instance of the objects' tables.

--- a/code/Migration.php
+++ b/code/Migration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PattricNelson\SilverStripeMigrations;
+namespace PatricNelson\SilverStripeMigrations;
 
 use Exception;
 

--- a/code/Migration.php
+++ b/code/Migration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PatricNelson\SilverStripeMigrations;
+namespace PatrickNelson\SilverStripeMigrations;
 
 use Exception;
 

--- a/code/MigrationBoilerplate.php
+++ b/code/MigrationBoilerplate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silverstripe\Migrations;
+namespace SilverStripe\Migrations;
 
 
 

--- a/code/MigrationBoilerplate.php
+++ b/code/MigrationBoilerplate.php
@@ -2,9 +2,6 @@
 
 namespace PattricNelson\SilverStripeMigrations;
 
-
-
-
 class MigrationBoilerplate extends Migration {
 
     /**

--- a/code/MigrationBoilerplate.php
+++ b/code/MigrationBoilerplate.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Silverstripe\Migrations;
+
+
+
+
 class MigrationBoilerplate extends Migration {
 
     /**

--- a/code/MigrationBoilerplate.php
+++ b/code/MigrationBoilerplate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Migrations;
+namespace PattricNelson\SilverStripeMigrations;
 
 
 

--- a/code/MigrationBoilerplate.php
+++ b/code/MigrationBoilerplate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PatricNelson\SilverStripeMigrations;
+namespace PatrickNelson\SilverStripeMigrations;
 
 class MigrationBoilerplate extends Migration {
 

--- a/code/MigrationBoilerplate.php
+++ b/code/MigrationBoilerplate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PattricNelson\SilverStripeMigrations;
+namespace PatricNelson\SilverStripeMigrations;
 
 class MigrationBoilerplate extends Migration {
 

--- a/code/MigrationException.php
+++ b/code/MigrationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Migrations;
+namespace PattricNelson\SilverStripeMigrations;
 
 use Exception;
 

--- a/code/MigrationException.php
+++ b/code/MigrationException.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace Silverstripe\Migrations;
+
+use Exception;
+
 /**
  * Setup only to better differentiate between exceptions coming directly from migration validation and any other
  * exceptions.

--- a/code/MigrationException.php
+++ b/code/MigrationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silverstripe\Migrations;
+namespace SilverStripe\Migrations;
 
 use Exception;
 

--- a/code/MigrationException.php
+++ b/code/MigrationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PattricNelson\SilverStripeMigrations;
+namespace PatricNelson\SilverStripeMigrations;
 
 use Exception;
 

--- a/code/MigrationException.php
+++ b/code/MigrationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PatricNelson\SilverStripeMigrations;
+namespace PatrickNelson\SilverStripeMigrations;
 
 use Exception;
 

--- a/code/MigrationInterface.php
+++ b/code/MigrationInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Silverstripe\Migrations;
+
+
+
+
 /**
  * Needed for consistency between unit tests and actual migrations.
  *

--- a/code/MigrationInterface.php
+++ b/code/MigrationInterface.php
@@ -2,9 +2,6 @@
 
 namespace PattricNelson\SilverStripeMigrations;
 
-
-
-
 /**
  * Needed for consistency between unit tests and actual migrations.
  *

--- a/code/MigrationInterface.php
+++ b/code/MigrationInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silverstripe\Migrations;
+namespace SilverStripe\Migrations;
 
 
 

--- a/code/MigrationInterface.php
+++ b/code/MigrationInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Migrations;
+namespace PattricNelson\SilverStripeMigrations;
 
 
 

--- a/code/MigrationInterface.php
+++ b/code/MigrationInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PattricNelson\SilverStripeMigrations;
+namespace PatricNelson\SilverStripeMigrations;
 
 /**
  * Needed for consistency between unit tests and actual migrations.

--- a/code/MigrationInterface.php
+++ b/code/MigrationInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PatricNelson\SilverStripeMigrations;
+namespace PatrickNelson\SilverStripeMigrations;
 
 /**
  * Needed for consistency between unit tests and actual migrations.

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,5 @@
     },
     "require-dev": {
         "sminnee/phpunit": "^5.7.29"
-    },
-    "extra": {
-        "installer-name": "migrations"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     },
     "autoload": {
         "psr-4": {
-            "SilverStripe\\Migrations\\": "code/",
-            "SilverStripe\\Migrations\\Tests\\": "tests/"
+            "PattricNelson\\SilverStripeMigrations\\": "code/",
+            "PattricNelson\\SilverStripeMigrations\\Tests\\": "tests/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "patricknelson/silverstripe-migrations",
     "description": "SilverStripe Database Migration module. Facilitates atomic database migrations in SilverStripe 3.x",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "homepage": "https://github.com/patricknelson/silverstripe-migrations",
     "keywords": [
         "silverstripe","database migrations","migrate"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,16 @@
     "require": {
         "silverstripe/cms": "^4.9.0"
     },
+    "require-dev": {
+        "sminnee/phpunit": "^5.7.29"
+    },
     "extra": {
         "installer-name": "migrations"
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,14 @@
     "support": {
         "issues": "https://github.com/patricknelson/silverstripe-migrations/issues"
     },
+    "autoload": {
+        "psr-4": {
+            "SilverStripe\\Migrations\\": "code/",
+            "SilverStripe\\Migrations\\Tests\\": "tests/"
+        }
+    },
     "require": {
-        "silverstripe/cms": "^3.0.0",
-        "silverstripe/framework": "^3.0.0"
+        "silverstripe/cms": "^4.9.0"
     },
     "extra": {
         "installer-name": "migrations"

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,8 @@
         "issues": "https://github.com/patricknelson/silverstripe-migrations/issues"
     },
     "autoload": {
-        "psr-4": {
-            "PattricNelson\\SilverStripeMigrations\\": "code/",
-            "PattricNelson\\SilverStripeMigrations\\Tests\\": "tests/"
-        }
+        "psr-4": { "PattricNelson\\SilverStripeMigrations\\": "code/" },
+        "classmap": { "PattricNelson\\SilverStripeMigrations\\Tests\\": "tests/" }
     },
     "require": {
         "silverstripe/cms": "^4.9.0"

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,5 @@
     },
     "extra": {
         "installer-name": "migrations"
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/installers": true,
-            "silverstripe/vendor-plugin": true
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,21 @@
         "issues": "https://github.com/patricknelson/silverstripe-migrations/issues"
     },
     "autoload": {
-        "psr-4": { "PattricNelson\\SilverStripeMigrations\\": "code/" },
-        "classmap": { "PattricNelson\\SilverStripeMigrations\\Tests\\": "tests/" }
+        "psr-4": { 
+            "PatricNelson\\SilverStripeMigrations\\": "code/",
+            "PatricNelson\\SilverStripeMigrations\\Tests\\": "tests/"
+        }
     },
     "require": {
         "silverstripe/cms": "^4.9.0"
     },
     "require-dev": {
         "sminnee/phpunit": "^5.7.29"
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     },
     "autoload": {
         "psr-4": { 
-            "PatricNelson\\SilverStripeMigrations\\": "code/",
-            "PatricNelson\\SilverStripeMigrations\\Tests\\": "tests/"
+            "PatrickNelson\\SilverStripeMigrations\\": "code/",
+            "PatrickNelson\\SilverStripeMigrations\\Tests\\": "tests/"
         }
     },
     "require": {

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -6,9 +6,9 @@ use Exception;
 
 use PattricNelson\SilverStripeMigrations\MigrateTask;
 use PattricNelson\SilverStripeMigrations\Migration;
+use PattricNelson\SilverStripeMigrations\MigrationInterface;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
-use PattricNelson\SilverStripeMigrations\MigrationInterface;
 use SilverStripe\ORM\DataObject;
 
 class MigrateTaskTest extends SapphireTest {

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -2,11 +2,6 @@
 
 namespace PattricNelson\SilverStripeMigrations\Tests;
 
-
-
-
-
-
 use Exception;
 
 use PattricNelson\SilverStripeMigrations\MigrateTask;
@@ -15,8 +10,6 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use PattricNelson\SilverStripeMigrations\MigrationInterface;
 use SilverStripe\ORM\DataObject;
-
-
 
 class MigrateTaskTest extends SapphireTest {
 

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -22,7 +22,7 @@ class MigrateTaskTest extends SapphireTest {
 
 	protected static $fixture_file = 'MigrateTaskTest.yml';
 
-    protected $extraDataObjects = [
+    protected $extra_dataobjects = [
         Migration_TestParent::class,
         Migration_TestChild::class,
         Migration_TestGrandchild::class,

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Migrations\Tests;
+namespace PattricNelson\SilverStripeMigrations\Tests;
 
 
 
@@ -9,11 +9,11 @@ namespace SilverStripe\Migrations\Tests;
 
 use Exception;
 
-use SilverStripe\Migrations\MigrateTask;
-use SilverStripe\Migrations\Migration;
+use PattricNelson\SilverStripeMigrations\MigrateTask;
+use PattricNelson\SilverStripeMigrations\Migration;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\Migrations\MigrationInterface;
+use PattricNelson\SilverStripeMigrations\MigrationInterface;
 use SilverStripe\ORM\DataObject;
 
 

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -20,9 +20,9 @@ use SilverStripe\ORM\DataObject;
 
 class MigrateTaskTest extends SapphireTest {
 
-	protected static $fixture_file = 'MigrateTaskTest.yml';
+    protected static $fixture_file = 'MigrateTaskTest.yml';
 
-    protected $extra_dataobjects = [
+    protected static $extra_dataobjects = [
         Migration_TestParent::class,
         Migration_TestChild::class,
         Migration_TestGrandchild::class,

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -117,7 +117,7 @@ class Migration_TestParent extends DataObject implements TestOnly {
     private static $db = [
         'ParentField' => 'Varchar(255)',
     ];
-
+    private static $table_name = 'Migration_TestParent';
 }
 
 class Migration_TestChild extends Migration_TestParent implements TestOnly {
@@ -125,7 +125,7 @@ class Migration_TestChild extends Migration_TestParent implements TestOnly {
     private static $db = [
         'ChildField' => 'Varchar(255)',
     ];
-
+    private static $table_name = 'Migration_TestChild';
 }
 
 class Migration_TestGrandchild extends Migration_TestChild implements TestOnly {
@@ -133,5 +133,5 @@ class Migration_TestGrandchild extends Migration_TestChild implements TestOnly {
     private static $db = [
         'Grandchild' => 'Varchar(255)',
     ];
-
+    private static $table_name = 'Migration_TestGrandchild';
 }

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -1,5 +1,23 @@
 <?php
 
+namespace Silverstripe\Migrations\Tests;
+
+
+
+
+
+
+use Exception;
+
+use Silverstripe\Migrations\MigrateTask;
+use Silverstripe\Migrations\Migration;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\TestOnly;
+use Silverstripe\Migrations\MigrationInterface;
+use SilverStripe\ORM\DataObject;
+
+
+
 class MigrateTaskTest extends SapphireTest {
 
 	protected static $fixture_file = 'MigrateTaskTest.yml';

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silverstripe\Migrations\Tests;
+namespace SilverStripe\Migrations\Tests;
 
 
 
@@ -9,11 +9,11 @@ namespace Silverstripe\Migrations\Tests;
 
 use Exception;
 
-use Silverstripe\Migrations\MigrateTask;
-use Silverstripe\Migrations\Migration;
+use SilverStripe\Migrations\MigrateTask;
+use SilverStripe\Migrations\Migration;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
-use Silverstripe\Migrations\MigrationInterface;
+use SilverStripe\Migrations\MigrationInterface;
 use SilverStripe\ORM\DataObject;
 
 

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace PattricNelson\SilverStripeMigrations\Tests;
+namespace PatricNelson\SilverStripeMigrations\Tests;
 
 use Exception;
 
-use PattricNelson\SilverStripeMigrations\MigrateTask;
-use PattricNelson\SilverStripeMigrations\Migration;
-use PattricNelson\SilverStripeMigrations\MigrationInterface;
+use PatricNelson\SilverStripeMigrations\MigrateTask;
+use PatricNelson\SilverStripeMigrations\Migration;
+use PatricNelson\SilverStripeMigrations\MigrationInterface;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;

--- a/tests/MigrateTaskTest.php
+++ b/tests/MigrateTaskTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace PatricNelson\SilverStripeMigrations\Tests;
+namespace PatrickNelson\SilverStripeMigrations\Tests;
 
 use Exception;
 
-use PatricNelson\SilverStripeMigrations\MigrateTask;
-use PatricNelson\SilverStripeMigrations\Migration;
-use PatricNelson\SilverStripeMigrations\MigrationInterface;
+use PatrickNelson\SilverStripeMigrations\MigrateTask;
+use PatrickNelson\SilverStripeMigrations\Migration;
+use PatrickNelson\SilverStripeMigrations\MigrationInterface;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;

--- a/tests/MigrateTaskTest.yml
+++ b/tests/MigrateTaskTest.yml
@@ -1,16 +1,16 @@
 DatabaseMigrations:
   test1:
     BaseName: 2015_04_27_000637_test1.php
-    MigrationClass: Migration_UnitTestOnly
+    MigrationClass: PattricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
     Batch: 1
     Stamp: 1430107790
   test2:
     BaseName: 2015_04_27_000638_test2.php
-    MigrationClass: Migration_UnitTestOnly
+    MigrationClass: PattricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
     Batch: 2
     Stamp: 1430107791
   test3:
     BaseName: 2015_04_27_000639_test3.php
-    MigrationClass: Migration_UnitTestOnly
+    MigrationClass: PattricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
     Batch: 2
     Stamp: 1430107792

--- a/tests/MigrateTaskTest.yml
+++ b/tests/MigrateTaskTest.yml
@@ -1,16 +1,16 @@
 DatabaseMigrations:
   test1:
     BaseName: 2015_04_27_000637_test1.php
-    MigrationClass: PattricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
+    MigrationClass: PatricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
     Batch: 1
     Stamp: 1430107790
   test2:
     BaseName: 2015_04_27_000638_test2.php
-    MigrationClass: PattricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
+    MigrationClass: PatricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
     Batch: 2
     Stamp: 1430107791
   test3:
     BaseName: 2015_04_27_000639_test3.php
-    MigrationClass: PattricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
+    MigrationClass: PatricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
     Batch: 2
     Stamp: 1430107792

--- a/tests/MigrateTaskTest.yml
+++ b/tests/MigrateTaskTest.yml
@@ -1,16 +1,16 @@
 DatabaseMigrations:
   test1:
     BaseName: 2015_04_27_000637_test1.php
-    MigrationClass: PatricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
+    MigrationClass: PatrickNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
     Batch: 1
     Stamp: 1430107790
   test2:
     BaseName: 2015_04_27_000638_test2.php
-    MigrationClass: PatricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
+    MigrationClass: PatrickNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
     Batch: 2
     Stamp: 1430107791
   test3:
     BaseName: 2015_04_27_000639_test3.php
-    MigrationClass: PatricNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
+    MigrationClass: PatrickNelson\SilverStripeMigrations\Tests\Migration_UnitTestOnly
     Batch: 2
     Stamp: 1430107792


### PR DESCRIPTION
Hi

SS4 compatibility upgrade. 

I followed steps and considerations from docs on:
- https://docs.silverstripe.org/en/4/upgrading/upgrading_module/
- https://docs.silverstripe.org/en/4/changelogs/4.0.0/

bypassed in most cases solving of any `@deprecated 5.0` and `TODO` parts. 

What is working:
- units test - all green
- some basic migrations task works on SS 4.9 as expected

I think that most migration work is done, but because of unit tests low coverage (TODOs in the code) and I don't have yet any more complex migrations tasks (I didn't use it before) please consider it as a beta version for the next release that needs few further tests.

Fixes patricknelson/silverstripe-migrations#15